### PR TITLE
Use the Dummy audio driver as Godello doesn't play any sounds

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -87,6 +87,10 @@ run/low_processor_mode=true
 run/low_processor_mode_sleep_usec=25000
 config/icon="res://icon.png"
 
+[audio]
+
+driver="Dummy"
+
 [autoload]
 
 Events="*res://scripts/Events.gd"


### PR DESCRIPTION
This prevents Godot from appearing as an application playing sound while Godello is running. This also decreases CPU usage (especially on macOS due to a known engine bug).